### PR TITLE
fixed bug on https and Safari

### DIFF
--- a/pman3.cgi
+++ b/pman3.cgi
@@ -3655,7 +3655,7 @@ EOM
 
 	$head2 .= <<EOM;
 <!-- 1. Add these JavaScript inclusions in the head of your page -->
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
 <script type="text/javascript" src="$path_highcharts/highcharts.js"></script>
 <!-- 1a) Optional: add a theme file -->
 <script type="text/javascript" src="$path_highcharts/themes/$theme_highcharts"></script>


### PR DESCRIPTION
If pman3 is running with https, pman3 can not load jquery.js because Safari does not allow loading javascript through http.
This fix will resolve this problem but we will not be able to run pman3 on the local machine (via file scheme).
For more information, please refer to the following url.
http://stackoverflow.com/questions/3583103/network-path-reference-uri-scheme-relative-urls
